### PR TITLE
Remove DCO and Email Address from DevOps Mutualization README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ DevOps Mutualization aims to solve common engineering problems by providing a co
 To initially unite SMEs from across FINOS members including Engineering, IT, Compliance, Security, Audit, etc. to identify 2-3 specific areas/projects where collaborative, open source, development could improve DevOps for FINOS members.
 
 ## How to contribute to DevOps Mutualization 
-Add your DevOps problems, or the opportunities you see in this area, to the [DevOps Mutualization GitHub Issues](https://github.com/finos-labs/devops-mutualization/issues) or by emailing james.mcleod@finos.org 
+Add your DevOps problems, or the opportunities you see in this area, to the [DevOps Mutualization GitHub Issues](https://github.com/finos-labs/devops-mutualization/issues). 
 
 ## License
 Copyright 2020 Fintech Open Source Foundation

--- a/README.md
+++ b/README.md
@@ -11,20 +11,6 @@ To initially unite SMEs from across FINOS members including Engineering, IT, Com
 ## How to contribute to DevOps Mutualization 
 Add your DevOps problems, or the opportunities you see in this area, to the [DevOps Mutualization GitHub Issues](https://github.com/finos-labs/devops-mutualization/issues) or by emailing james.mcleod@finos.org 
 
-## Using DCO to sign your commits
-All commits into DevOps Mutualization must be signed with a DCO signature to avoid being flagged by the DCO Bot. This means that your commit log message must contain a line that looks like the following one, with your actual name and email address:
-
-```
-Signed-off-by: John Doe <john.doe@example.com>
-```
-
-Adding the `-s` flag to your `git commit` will add that line automatically. You can also add it manually as part of your commit log message or add it afterwards with `git commit --amend -s`.
-
-### Helpful DCO Resources
-- [Git Tools - Signing Your Work](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work)
-- [Signing commits
-](https://docs.github.com/en/github/authenticating-to-github/signing-commits)
-
 ## License
 Copyright 2020 Fintech Open Source Foundation
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ To initially unite SMEs from across FINOS members including Engineering, IT, Com
 ## How to contribute to DevOps Mutualization 
 Add your DevOps problems, or the opportunities you see in this area, to the [DevOps Mutualization GitHub Issues](https://github.com/finos-labs/devops-mutualization/issues). 
 
+## Mailing List
+Subscribe to the DevOps Mutualization mailing list by sending an email to devops-mutualization+subscribe@finos.org.
+
 ## License
 Copyright 2020 Fintech Open Source Foundation
 


### PR DESCRIPTION
## Description

This pull request updates the DevOps Mutualization README.md following the SIG transfer to the parent FINOS organisation (CCLA) from FINOS Labs (DCO).

- remove DCO references c4c59bd
- remove james mcleod email address 710438c
- add DevOps Mutualization mailing list 7e40665