### PR TITLE
Add WebEx, Mailing List, Meeting Notices and FINOS Antitrust Policy Slide to GitHub Agenda Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Meeting.md
+++ b/.github/ISSUE_TEMPLATE/Meeting.md
@@ -10,6 +10,15 @@ _day-of-week_ DD MMM yyyy - _time_ EST / _time_ UK
 | Name | Firm | Comment |
 |:---------|:------------|:-----|
 
+## Meeting notices
+- FINOS **Project leads** are responsible for observing the FINOS guidelines for [running project meetings](https://github.com/finos/community/blob/master/governance/Meeting-Procedures.md#run-the-meeting). Project maintainers can find additional resources in the [FINOS Maintainers Cheatsheet](https://odp.finos.org/docs/finos-maintainers-cheatsheet/).
+
+- **All participants** in FINOS project meetings are subject to the [LF Antitrust Policy](https://www.linuxfoundation.org/antitrust-policy/), the [FINOS Community Code of Conduct](https://github.com/finos/community/blob/master/governance/Code-of-Conduct.md) and all other [FINOS policies](https://github.com/finos/community/tree/master/governance#policies). 
+
+- FINOS meetings involve participation by industry competitors, and it is the intention of FINOS and the Linux Foundation to conduct all of its activities in accordance with applicable antitrust and competition laws. It is therefore extremely important that attendees adhere to meeting agendas, and be aware of, and not participate in, any activities that are prohibited under applicable US state, federal or foreign antitrust and competition laws. Please contact legal@finos.org with any questions.
+
+- FINOS project meetings may be recorded for use solely by the FINOS team for administration purposes. In very limited instances, and with explicit approval, recordings may be made more widely available.
+
 ## Agenda
 
 - [ ] Convene, roll call, welcome new people

--- a/.github/ISSUE_TEMPLATE/Meeting.md
+++ b/.github/ISSUE_TEMPLATE/Meeting.md
@@ -22,6 +22,7 @@ _day-of-week_ DD MMM yyyy - _time_ EST / _time_ UK
 ## Agenda
 
 - [ ] Convene, roll call, welcome new people
+- [ ] Display [FINOS Antitrust Policy summary slide](https://github.com/finos/community/blob/master/governance/Compliance-Slides/Antitrust-Compliance-Slide.pdf) 
 - [ ] Approve previous meeting minutes
 - [ ] _Add Items Here_
 - [ ] AOB, Q&A & Adjourn (5mins)

--- a/.github/ISSUE_TEMPLATE/Meeting.md
+++ b/.github/ISSUE_TEMPLATE/Meeting.md
@@ -29,9 +29,13 @@ _day-of-week_ DD MMM yyyy - _time_ EST / _time_ UK
 
 ### WebEx info
 **Webex:** 
-- _webex-link_
+https://finos.webex.com/finos/j.php?MTID=md62056638ba05fbea86b9582df94f807
 
 ### Dial-in
 - **US** +1-415-655-0003 US Toll
 - **UK** +44-20319-88141 UK Toll
-- **Access code:** _webex-access-code_
+- **Access code:** 127 662 6070
+
+**Github Repo:** https://github.com/finos/devops-mutualization/
+
+**Mailing List:** Email devops-mutualization+subscribe@finos.org to subscribe to our mailing list


### PR DESCRIPTION
## Description

This pull request adds the following items to the DevOps Mutualization meeting agenda template ...

- Webex details for meetings scheduled the 3rd Thursday of each month from Thursday 21st January 2021 @ 12pm ET / 5pm GMT onwards
- How to subscribe to the DevOps Mutualization mailing list
- FINOS meeting notices cc @aitana16 
- FINOS antitrust policy slide cc @aitana16

## Template Additions

### FINOS Meeting Notices
```
## Meeting notices
- FINOS **Project leads** are responsible for observing the FINOS guidelines for [running project meetings](https://github.com/finos/community/blob/master/governance/Meeting-Procedures.md#run-the-meeting). Project maintainers can find additional resources in the [FINOS Maintainers Cheatsheet](https://odp.finos.org/docs/finos-maintainers-cheatsheet/).

- **All participants** in FINOS project meetings are subject to the [LF Antitrust Policy](https://www.linuxfoundation.org/antitrust-policy/), the [FINOS Community Code of Conduct](https://github.com/finos/community/blob/master/governance/Code-of-Conduct.md) and all other [FINOS policies](https://github.com/finos/community/tree/master/governance#policies). 

- FINOS meetings involve participation by industry competitors, and it is the intention of FINOS and the Linux Foundation to conduct all of its activities in accordance with applicable antitrust and competition laws. It is therefore extremely important that attendees adhere to meeting agendas, and be aware of, and not participate in, any activities that are prohibited under applicable US state, federal or foreign antitrust and competition laws. Please contact legal@finos.org with any questions.

- FINOS project meetings may be recorded for use solely by the FINOS team for administration purposes. In very limited instances, and with explicit approval, recordings may be made more widely available.
```

### FINOS Antitrust Policy Slide
```
- [ ] Display [FINOS Antitrust Policy summary slide](https://github.com/finos/community/blob/master/governance/Compliance-Slides/Antitrust-Compliance-Slide.pdf) 
```

### DevOps Mutualization Webex and Mailing List Details
```
### WebEx info
**Webex:** 
https://finos.webex.com/finos/j.php?MTID=md62056638ba05fbea86b9582df94f807

### Dial-in
- **US** +1-415-655-0003 US Toll
- **UK** +44-20319-88141 UK Toll
- **Access code:** 127 662 6070

**Github Repo:** https://github.com/finos/devops-mutualization/

**Mailing List:** Email devops-mutualization+subscribe@finos.org to subscribe to our mailing list
```

## Commits 
- add webex and mailing list details to meeting.md f3ed4d5
- add FINOS meeting notices 00c5089
- add FINOS policy slide to agenda f368f3e
- Merge branch 'master' into add-webex-details 2c2bc77
