### PR TITLE
Remove FINOS Active Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 # DevOps Mutualization
 
-[![FINOS - Active](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-active.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Active)
-
 ## What is DevOps Mutualization?
 DevOps Mutualization aims to solve common engineering problems by providing a continuous compliance and assurance approach to DevOps that mutually benefits banks, auditors and regulators whilst accelerating DevOps adoption in engineering and fintech IT departments.
 


### PR DESCRIPTION
## Description
This pull request removes the DevOps Mutualization `Active` badge due to DevOps Mutualization being a FINOS Special Interest Group, and not a FINOS Project. This means the `Active` badge is not required.

## Removed Markdown
```
- [![FINOS - Active](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-active.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Active)
```
## Commits 
- remove active badge 505de75