### PR TITLE
Add GitHub Team Discussions Instructions to the SIG README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ All SIG related communications are conducted through the devops-mutualization@fi
 
 Subscribe to the DevOps Mutualization mailing list by sending an email to devops-mutualization+subscribe@finos.org.
 
+## DevOps Mutualization SIG Discussions
+
+DevOps Mutualization uses [GitHub Team Discussions](https://odp.finos.org/docs/project-collaboration#github-team-discussions) for SIG wide discussions that are only visible to members of the [FINOS GitHub Organisation](https://github.com/orgs/finos/people), with optional `private` discussions available to those who are part of the [devops-mutualization-participants](https://github.com/orgs/finos/teams/devops-mutualization-participants/) team.
+
+Find out [how to join DevOps Mutualization SIG Discussions](https://github.com/finos/devops-mutualization/blob/master/docs/Discussions.md).
+
 ## License
 Copyright 2020 Fintech Open Source Foundation
 


### PR DESCRIPTION
## Description

This pull request adds DevOps Mutualization GitHub Team Discussions instructions to the SIG `README.md`.

# Markdown

```
## DevOps Mutualization SIG Discussions

DevOps Mutualization uses [GitHub Team Discussions](https://odp.finos.org/docs/project-collaboration#github-team-discussions) for SIG wide discussions that are only visible to members of the [FINOS GitHub Organisation](https://github.com/orgs/finos/people), with optional `private` discussions available to those who are part of the [devops-mutualization-participants](https://github.com/orgs/finos/teams/devops-mutualization-participants/) team.

Find out [how to join DevOps Mutualization SIG Discussions](https://github.com/finos/devops-mutualization/blob/master/docs/Discussions.md).
```

# Instructions  Preview

## DevOps Mutualization SIG Discussions

DevOps Mutualization uses [GitHub Team Discussions](https://odp.finos.org/docs/project-collaboration#github-team-discussions) for SIG wide discussions that are only visible to members of the [FINOS GitHub Organisation](https://github.com/orgs/finos/people), with optional `private` discussions available to those who are part of the [devops-mutualization-participants](https://github.com/orgs/finos/teams/devops-mutualization-participants/) team.

Find out [how to join DevOps Mutualization SIG Discussions](https://github.com/finos/devops-mutualization/blob/master/docs/Discussions.md).