### PR TITLE
Add DevOps Mutualization Project Operations Manager Role

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Subscribe to the DevOps Mutualization mailing list by sending an email to devops
 
 ## DevOps Mutualization Open Team Roles
 
-The DevOps Mutualization leadership team needs your help to run the FINOS Special Interest Group. The following are our [Open SIG Team Roles](docs/open-roles) for those who'd like to get involved.
+The DevOps Mutualization leadership team needs your help to run the FINOS Special Interest Group. The following are our [Open DevOps Mutualization SIG Team Roles](docs/open-roles) for those who'd like to get involved.
 
 * [Project Operations Manager - DevOps Mutualization](docs/open-roles/project-operations-manager.md)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Subscribe to the DevOps Mutualization mailing list by sending an email to devops
 
 ## DevOps Mutualization Open Team Roles
 
-DevOps Mutualization needs your help to run the FINOS Special Interest Group. The following is a list of the [Open DevOps Mutualization Roles](docs/open-roles).
+DevOps Mutualization needs your help to run the FINOS Special Interest Group.
+
+The following is a list of the [Open DevOps Mutualization Roles](docs/open-roles).
 
 * [Project Operations Manager - DevOps Mutualization](docs/open-roles/project-operations-manager.md)
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ Subscribe to the DevOps Mutualization mailing list by sending an email to devops
 
 ## DevOps Mutualization Open Team Roles
 
-DevOps Mutualization needs your help to run the FINOS Special Interest Group.
-
-The following is a list of the [Open DevOps Mutualization Roles](docs/open-roles).
+The DevOps Mutualization leadership team needs your help to run the FINOS Special Interest Group. The following are our [Open SIG Team Roles](docs/open-roles) for those who'd like to get involved.
 
 * [Project Operations Manager - DevOps Mutualization](docs/open-roles/project-operations-manager.md)
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ All SIG related communications are conducted through the devops-mutualization@fi
 
 Subscribe to the DevOps Mutualization mailing list by sending an email to devops-mutualization+subscribe@finos.org.
 
+## Open Roles - DevOps Mutualization
+
+DevOps Mutualization needs your help to run the FINOS Special Interest Group.
+
+The following is a list of the [open DevOps Mutualization roles](docs/open-roles).
+
+* [Project Operations Manager - DevOps Mutualization](docs/open-roles/project-operations-manager.md)
+
 ## DevOps Mutualization SIG Discussions
 
 DevOps Mutualization uses [GitHub Team Discussions](https://odp.finos.org/docs/project-collaboration#github-team-discussions) for SIG wide discussions that are only visible to members of the [FINOS GitHub Organisation](https://github.com/orgs/finos/people), with optional `private` discussions available to those who are part of the [devops-mutualization-participants](https://github.com/orgs/finos/teams/devops-mutualization-participants/) team. 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ Subscribe to the DevOps Mutualization mailing list by sending an email to devops
 
 ## DevOps Mutualization Open Team Roles
 
-DevOps Mutualization needs your help to run the FINOS Special Interest Group.
-
-The following is a list of the [open DevOps Mutualization roles](docs/open-roles).
+DevOps Mutualization needs your help to run the FINOS Special Interest Group. The following is a list of the [Open DevOps Mutualization Roles](docs/open-roles).
 
 * [Project Operations Manager - DevOps Mutualization](docs/open-roles/project-operations-manager.md)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All SIG related communications are conducted through the devops-mutualization@fi
 
 Subscribe to the DevOps Mutualization mailing list by sending an email to devops-mutualization+subscribe@finos.org.
 
-## Open Roles - DevOps Mutualization
+## DevOps Mutualization Open Team Roles
 
 DevOps Mutualization needs your help to run the FINOS Special Interest Group.
 

--- a/docs/open-roles/README.md
+++ b/docs/open-roles/README.md
@@ -6,6 +6,6 @@ The following is a list of the open DevOps Mutualization roles.
 
 ## Contact DevOps Mutualization
 
-Contact [James McLeod](james@finos.org), FINOS Director of Community, or [Amol Shukla](amol.shukla@morganstanley.com) and [Anders Wallgren](awallgren@cloudbees.com) for more information or drop into the next [DevOps Mutualization SIG Meeting](https://github.com/finos/devops-mutualization/issues?q=label%3Ameeting+) to say hello.
+Contact [James McLeod](james@finos.org), FINOS Director of Community, or [Amol Shukla](amol.shukla@morganstanley.com), Morgan Stanley Executive Director and [Anders Wallgren](awallgren@cloudbees.com), CloudBees Vice President of Technology Strategy, for more information or drop into the next [DevOps Mutualization SIG Meeting](https://github.com/finos/devops-mutualization/issues?q=label%3Ameeting+) to say hello.
 
 🌤 🚀 🤖

--- a/docs/open-roles/README.md
+++ b/docs/open-roles/README.md
@@ -1,12 +1,11 @@
-# Open Roles - Cloud Service Certification
+# Open Roles - DevOps Mutualization
 
-The following is a list of the open Cloud Service Certification roles.
+The following is a list of the open DevOps Mutualization roles.
 
-* [CSC Project Maintainer - Cloud Service Certification](cloud-service-certification-project-maintainer.md)
-* [Project Operations Manager - Cloud Service Certification](project-operations-manager.md)
+* [Project Operations Manager - DevOps Mutualization](project-operations-manager.md)
 
-## Contact Cloud Service Certification
+## Contact DevOps Mutualization
 
-Contact [James McLeod](james@finos.org), FINOS Director of Community, or  [Peter Thomas](peter.thomas@db.com), Cloud Service Certification Lead Maintainer from Deutsche Bank, for more information or drop into the next [Cloud Service Certification Project Meeting](https://github.com/finos/cloud-service-certification/issues?q=label%3Ameeting+) to say hello.
+Contact [James McLeod](james@finos.org), FINOS Director of Community, or [Amol Shukla](amol.shukla@morganstanley.com) and [Anders Wallgren](awallgren@cloudbees.com) for more information or drop into the next [DevOps Mutualization SIG Meeting](https://github.com/finos/devops-mutualization/issues?q=label%3Ameeting+) to say hello.
 
 🌤 🚀 🤖

--- a/docs/open-roles/README.md
+++ b/docs/open-roles/README.md
@@ -1,0 +1,12 @@
+# Open Roles - Cloud Service Certification
+
+The following is a list of the open Cloud Service Certification roles.
+
+* [CSC Project Maintainer - Cloud Service Certification](cloud-service-certification-project-maintainer.md)
+* [Project Operations Manager - Cloud Service Certification](project-operations-manager.md)
+
+## Contact Cloud Service Certification
+
+Contact [James McLeod](james@finos.org), FINOS Director of Community, or  [Peter Thomas](peter.thomas@db.com), Cloud Service Certification Lead Maintainer from Deutsche Bank, for more information or drop into the next [Cloud Service Certification Project Meeting](https://github.com/finos/cloud-service-certification/issues?q=label%3Ameeting+) to say hello.
+
+🌤 🚀 🤖

--- a/docs/open-roles/README.md
+++ b/docs/open-roles/README.md
@@ -6,6 +6,6 @@ The following is a list of the open DevOps Mutualization roles.
 
 ## Contact DevOps Mutualization
 
-Contact [James McLeod](james@finos.org), FINOS Director of Community, or [Amol Shukla](amol.shukla@morganstanley.com), Morgan Stanley Executive Director and [Anders Wallgren](awallgren@cloudbees.com), CloudBees Vice President of Technology Strategy, for more information or drop into the next [DevOps Mutualization SIG Meeting](https://github.com/finos/devops-mutualization/issues?q=label%3Ameeting+) to say hello.
+Contact [James McLeod](james@finos.org), FINOS Director of Community, or [Amol Shukla](amol.shukla@morganstanley.com), Morgan Stanley Executive Director, and [Anders Wallgren](awallgren@cloudbees.com), CloudBees Vice President of Technology Strategy, for more information or drop into the next [DevOps Mutualization SIG Meeting](https://github.com/finos/devops-mutualization/issues?q=label%3Ameeting+) to say hello.
 
 🌤 🚀 🤖

--- a/docs/open-roles/project-operations-manager.md
+++ b/docs/open-roles/project-operations-manager.md
@@ -28,6 +28,6 @@ The Project Operations Manager works closely with the DevOps Mutualization SIG L
 
 ## Contact DevOps Mutualization
 
-Contact [James McLeod](james@finos.org), FINOS Director of Community, or [Amol Shukla](amol.shukla@morganstanley.com), Morgan Stanley Executive Director and [Anders Wallgren](awallgren@cloudbees.com), CloudBees Vice President of Technology Strategy, for more information or drop into the next [DevOps Mutualization SIG Meeting](https://github.com/finos/devops-mutualization/issues?q=label%3Ameeting+) to say hello.
+Contact [James McLeod](james@finos.org), FINOS Director of Community, or [Amol Shukla](amol.shukla@morganstanley.com), Morgan Stanley Executive Director, and [Anders Wallgren](awallgren@cloudbees.com), CloudBees Vice President of Technology Strategy, for more information or drop into the next [DevOps Mutualization SIG Meeting](https://github.com/finos/devops-mutualization/issues?q=label%3Ameeting+) to say hello.
 
 🌤 🚀 🤖

--- a/docs/open-roles/project-operations-manager.md
+++ b/docs/open-roles/project-operations-manager.md
@@ -1,0 +1,33 @@
+# Project Operations Manager - DevOps Mutualization 
+Helping run [DevOps Mutualization](https://github.com/finos/devops-mutualization) as Project Operations Manager is a fun open source role involving a broad set of tasks that need to be taken care of, including ... 
+
+## Role Requirements
+
+- Capturing, writing and updating work items as [GitHub Issues](https://github.com/finos/devops-mutualization/issues).
+- Updating and running the DevOps Mutualization Project Kanban.
+- Communicating with the SIG and associated SIG project teams.
+- Updating the [FINOS Community](https://github.com/finos/community/issues).
+
+The DevOps Mutualization Project Operations Manager does not necessarily have to be technical, or a subject matter expert, but should have ...
+
+## Skills Requirements
+
+- Strong organization skills.
+- Attention to detail.
+- Curiosity and proactiveness.
+- Willingness to have fun growing DevOps Mutualization.
+
+The Project Operations Manager will need to be (or become) ... 
+
+- Comfortable using GitHub.
+- Comfortable coordinating meetings using WebEx. 
+
+The Project Operations Manager will have to understand the [FINOS Landscape](https://landscape.finos.org), [Open Developer Platform](https://github.com/finos/open-developer-platform) and [FINOS Governance and Policies](https://github.com/finos/community/tree/master/governance). 
+
+The Project Operations Manager works closely with the DevOps Mutualization SIG Lead and SIG Secretary to ensure the SIG collaborates smoothly. The Project Operations Manager will reach out to FINOS for assistance and support as they need it.
+
+## Contact DevOps Mutualization
+
+Contact [James McLeod](james@finos.org), FINOS Director of Community, or [Amol Shukla](amol.shukla@morganstanley.com) and [Anders Wallgren](awallgren@cloudbees.com) for more information or drop into the next [DevOps Mutualization SIG Meeting](https://github.com/finos/devops-mutualization/issues?q=label%3Ameeting+) to say hello.
+
+🌤 🚀 🤖

--- a/docs/open-roles/project-operations-manager.md
+++ b/docs/open-roles/project-operations-manager.md
@@ -28,6 +28,6 @@ The Project Operations Manager works closely with the DevOps Mutualization SIG L
 
 ## Contact DevOps Mutualization
 
-Contact [James McLeod](james@finos.org), FINOS Director of Community, or [Amol Shukla](amol.shukla@morganstanley.com) and [Anders Wallgren](awallgren@cloudbees.com) for more information or drop into the next [DevOps Mutualization SIG Meeting](https://github.com/finos/devops-mutualization/issues?q=label%3Ameeting+) to say hello.
+Contact [James McLeod](james@finos.org), FINOS Director of Community, or [Amol Shukla](amol.shukla@morganstanley.com), Morgan Stanley Executive Director and [Anders Wallgren](awallgren@cloudbees.com), CloudBees Vice President of Technology Strategy, for more information or drop into the next [DevOps Mutualization SIG Meeting](https://github.com/finos/devops-mutualization/issues?q=label%3Ameeting+) to say hello.
 
 🌤 🚀 🤖


### PR DESCRIPTION
## Description
This pull request add the Project Operations Manager role to the DevOps Mutualization repository.

## Added and Updated Files
The files that were added / updated within the DevOps Mutualization repository are ...

- `README.md`
- `docs/open-roles/README.md`
- `docs/open-roles/project-operations-manager.md`

## Commits

- add project operations manager role 256d54e
- Merge branch 'master' into add-project-role 5a4ae94
- update open roles README 25808ea
- update SIG README 6847da7
- update SIG README 6b2ca95
- update SIG README a9b83b1
- update SIG README 644bc84
- update SIG README 8403dd3
- update SIG README 410979b
- update job titles 7fb731e
- update job titles 9d1483c
